### PR TITLE
Address RabbitMQ depreciation of "transient_nonexcl_queues"

### DIFF
--- a/source/Ansible-Protocol-Core/AmqpQueueDeclareBuilder.class.st
+++ b/source/Ansible-Protocol-Core/AmqpQueueDeclareBuilder.class.st
@@ -64,7 +64,7 @@ AmqpQueueDeclareBuilder >> initializeFor: aProtocolVersion [
 	protocolVersion := aProtocolVersion.
 	"Initialize default values."
 	queueName := ''.
-	durable := false.
+	durable := true.
 	exclusive := false.
 	autoDelete := false.
 	passive := false.

--- a/source/Ansible-Protocol-Core/AmqpQueueDeclareBuilder.class.st
+++ b/source/Ansible-Protocol-Core/AmqpQueueDeclareBuilder.class.st
@@ -26,10 +26,17 @@ AmqpQueueDeclareBuilder >> autoDelete [
 	autoDelete := true
 ]
 
-{ #category : 'configuring' }
+{ #category : 'configuring - deprecated' }
 AmqpQueueDeclareBuilder >> beDurable [
 	
+	self deprecated: 'Deprecated as queues are initialized as durable by default'.
 	durable := true
+]
+
+{ #category : 'configuring' }
+AmqpQueueDeclareBuilder >> beTransient [
+	
+	durable := false
 ]
 
 { #category : 'configuring' }


### PR DESCRIPTION
Transient (i.e., durable set to false) and non-exclusive queues are deprecated and in the future will not be supported by RabbitMQ: https://www.rabbitmq.com/release-information/deprecated-features-list